### PR TITLE
통계를 위한 조건에 맞는 user timetables 불러오기 구현

### DIFF
--- a/components/main/ConditionSelector.tsx
+++ b/components/main/ConditionSelector.tsx
@@ -1,40 +1,39 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import type { TypeColleges, TypeMajorMap } from '@/types/timetable';
 import Select from '@/components/MuiSelect';
-import { GRADES } from '@/consts/timetable';
 import Button from '@mui/material/Button';
 
 interface IConditionSelector {
   semesters: string[];
-  majorMap: TypeMajorMap;
-  handleSearch: (
-    semester: string,
-    college: string,
-    major: string,
-    grade: string,
-  ) => void;
+  semester: string;
+  setSemester: React.Dispatch<React.SetStateAction<string>>;
+  colleges: string[];
+  college: string;
+  setCollege: React.Dispatch<React.SetStateAction<string>>;
+  majors: string[];
+  major: string;
+  setMajor: React.Dispatch<React.SetStateAction<string>>;
+  grades: string[];
+  grade: string;
+  setGrade: React.Dispatch<React.SetStateAction<string>>;
+  handleSearch: () => void;
 }
 
 export default function ConditionSelector({
   semesters,
-  majorMap,
+  semester,
+  setSemester,
+  colleges,
+  college,
+  setCollege,
+  majors,
+  major,
+  setMajor,
+  grades,
+  grade,
+  setGrade,
   handleSearch,
 }: IConditionSelector) {
-  const {
-    semester,
-    setSemester,
-    colleges,
-    college,
-    setCollege,
-    majors,
-    major,
-    setMajor,
-    grades,
-    grade,
-    setGrade,
-  } = useCondition(semesters, majorMap);
-
   return (
     <Wrapper>
       <SelectWrapper>
@@ -64,51 +63,12 @@ export default function ConditionSelector({
         />
       </SelectWrapper>
       <ButtonWrapper>
-        <StyledButton
-          variant='contained'
-          onClick={() => {
-            handleSearch(semester, college, major, grade);
-          }}
-        >
+        <StyledButton variant='contained' onClick={handleSearch}>
           검색
         </StyledButton>
       </ButtonWrapper>
     </Wrapper>
   );
-}
-
-function useCondition(semesters: string[], majorMap: TypeMajorMap) {
-  const [semester, setSemester] = useState(semesters[0]);
-
-  const colleges = ['모든 단과대학', ...Object.keys(majorMap)];
-  const [college, setCollege] = useState(colleges[0]);
-
-  const majors =
-    college === colleges[0]
-      ? ['모든 과']
-      : ['모든 과', ...majorMap[college as TypeColleges]];
-  const [major, setMajor] = useState(majors[0]);
-
-  const grades = ['모든 학년', ...GRADES];
-  const [grade, setGrade] = useState(grades[0]);
-
-  useEffect(() => {
-    setMajor(majors[0]);
-  }, [college]);
-
-  return {
-    semester,
-    setSemester,
-    colleges,
-    college,
-    setCollege,
-    majors,
-    major,
-    setMajor,
-    grades,
-    grade,
-    setGrade,
-  };
 }
 
 const Wrapper = styled.div`

--- a/components/main/ConditionSelector.tsx
+++ b/components/main/ConditionSelector.tsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import type { TypeColleges, TypeMajorMap } from '@/types/timetable';
+import Select from '@/components/MuiSelect';
+import { GRADES } from '@/consts/timetable';
+import Button from '@mui/material/Button';
+
+interface IConditionSelector {
+  semesters: string[];
+  majorMap: TypeMajorMap;
+  handleSearch: (
+    semester: string,
+    college: string,
+    major: string,
+    grade: string,
+  ) => void;
+}
+
+export default function ConditionSelector({
+  semesters,
+  majorMap,
+  handleSearch,
+}: IConditionSelector) {
+  const {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  } = useCondition(semesters, majorMap);
+
+  return (
+    <Wrapper>
+      <SelectWrapper>
+        <Select
+          items={semesters}
+          value={semester}
+          onChange={setSemester}
+          width={'100%'}
+        />
+        <Select
+          items={colleges}
+          value={college}
+          onChange={setCollege}
+          width={'100%'}
+        />
+        <Select
+          items={majors}
+          value={major}
+          onChange={setMajor}
+          width={'100%'}
+        />
+        <Select
+          items={grades}
+          value={grade}
+          onChange={setGrade}
+          width={'100%'}
+        />
+      </SelectWrapper>
+      <ButtonWrapper>
+        <StyledButton
+          variant='contained'
+          onClick={() => {
+            handleSearch(semester, college, major, grade);
+          }}
+        >
+          검색
+        </StyledButton>
+      </ButtonWrapper>
+    </Wrapper>
+  );
+}
+
+function useCondition(semesters: string[], majorMap: TypeMajorMap) {
+  const [semester, setSemester] = useState(semesters[0]);
+
+  const colleges = ['모든 단과대학', ...Object.keys(majorMap)];
+  const [college, setCollege] = useState(colleges[0]);
+
+  const majors =
+    college === colleges[0]
+      ? ['모든 과']
+      : ['모든 과', ...majorMap[college as TypeColleges]];
+  const [major, setMajor] = useState(majors[0]);
+
+  const grades = ['모든 학년', ...GRADES];
+  const [grade, setGrade] = useState(grades[0]);
+
+  useEffect(() => {
+    setMajor(majors[0]);
+  }, [college]);
+
+  return {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  };
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  @media (min-width: ${({ theme: { size } }) => size.mobile}) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+  gap: 5px;
+`;
+
+const SelectWrapper = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+
+  @media (min-width: ${({ theme: { size } }) => size.mobile}) {
+    display: flex;
+  }
+  gap: 5px;
+`;
+const ButtonWrapper = styled.div`
+  display: flex;
+`;
+
+const StyledButton = styled(Button)`
+  width: 100%;
+`;

--- a/components/timetable/selector/SaveDialog.tsx
+++ b/components/timetable/selector/SaveDialog.tsx
@@ -8,7 +8,7 @@ import Button from '@mui/material/Button';
 interface ISaveDialog {
   majorMap: TypeMajorMap;
   handleClose: () => void;
-  handleSave: (major: string, grade: string) => void;
+  handleSave: (college: string, major: string, grade: string) => void;
 }
 
 export default function SaveDialog({
@@ -70,7 +70,7 @@ export default function SaveDialog({
         </StyledButton>
         <StyledButton
           variant='outlined'
-          onClick={() => handleSave(major, grade)}
+          onClick={() => handleSave(college, major, grade)}
         >
           저장
         </StyledButton>

--- a/pages/api/timetable/statistics/get.ts
+++ b/pages/api/timetable/statistics/get.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import client from '@/prisma/client';
+import type { IUserTimetablesResponse } from '@/types/apiResponse';
+import { Timetables } from '@prisma/client';
+import type { ITimetable } from '@/types/timetable';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<IUserTimetablesResponse>,
+) {
+  const { semester, college, major, grade } = req.query;
+  if (!semester || !college || !major || !grade) {
+    res
+      .status(200)
+      .json({ ok: false, message: '불러오기 실패 - query string 오류' });
+    return;
+  }
+
+  try {
+    const result = await client.timetables.findMany({
+      where: {
+        AND: {
+          semester: {
+            equals: semester as string,
+          },
+          college: isAll(college)
+            ? undefined
+            : {
+                equals: college as string,
+              },
+          major: isAll(major)
+            ? undefined
+            : {
+                equals: major as string,
+              },
+          grade: isAll(grade)
+            ? undefined
+            : {
+                equals: grade as string,
+              },
+        },
+      },
+      take: 500,
+    });
+
+    if (result) {
+      const userTimetables = parseUserTimetablesObject(result);
+      res
+        .status(200)
+        .json({ ok: true, message: '불러오기 완료', userTimetables });
+    } else if (!result) {
+      res.status(200).json({ ok: true, message: '저장된 시간표가 없음' });
+    }
+  } catch {
+    res
+      .status(200)
+      .json({ ok: false, message: '불러오기 실패 - 데이터베이스 오류' });
+  }
+}
+
+function isAll(target: string | string[] | undefined) {
+  return (target as string).includes('모든');
+}
+
+function parseUserTimetablesObject(result: Timetables[]) {
+  const userTimetables = result.map(
+    ({
+      id,
+      nickname,
+      semester,
+      college,
+      major,
+      grade,
+      totalGrades,
+      timetables,
+    }) => {
+      return {
+        id,
+        nickname,
+        semester,
+        college,
+        major,
+        grade,
+        totalGrades,
+        timetables: JSON.parse(timetables as string) as ITimetable[],
+      };
+    },
+  );
+
+  return userTimetables;
+}

--- a/pages/api/timetable/user/get.ts
+++ b/pages/api/timetable/user/get.ts
@@ -30,13 +30,22 @@ export default async function handler(
     });
 
     if (result) {
-      const { id, nickname, semester, major, grade, totalGrades, timetables } =
-        result;
+      const {
+        id,
+        nickname,
+        semester,
+        college,
+        major,
+        grade,
+        totalGrades,
+        timetables,
+      } = result;
 
       const userTimetable = {
         id,
         nickname,
         semester,
+        college,
         major,
         grade,
         totalGrades,

--- a/pages/api/timetable/user/get.ts
+++ b/pages/api/timetable/user/get.ts
@@ -52,7 +52,9 @@ export default async function handler(
         timetables: JSON.parse(timetables as string) as ITimetable[],
       };
 
-      res.status(200).json({ ok: true, message: '저장 완료', userTimetable });
+      res
+        .status(200)
+        .json({ ok: true, message: '불러오기 완료', userTimetable });
     } else if (!result) {
       res.status(200).json({ ok: true, message: '저장된 시간표가 없음' });
     }

--- a/pages/api/timetable/user/post.ts
+++ b/pages/api/timetable/user/post.ts
@@ -16,8 +16,16 @@ export default async function handler(
     return;
   }
 
-  const { id, nickname, semester, major, grade, totalGrades, timetables } =
-    req.body;
+  const {
+    id,
+    nickname,
+    semester,
+    college,
+    major,
+    grade,
+    totalGrades,
+    timetables,
+  } = req.body;
 
   try {
     await client.timetables.create({
@@ -25,6 +33,7 @@ export default async function handler(
         id,
         nickname,
         semester,
+        college,
         major,
         grade,
         totalGrades,

--- a/pages/my/add/[semester].tsx
+++ b/pages/my/add/[semester].tsx
@@ -111,7 +111,11 @@ export default function Add({ semester, timetables }: IAdd) {
     openDialog();
   };
 
-  const handleSaveAddedTimetables = async (major: string, grade: string) => {
+  const handleSaveAddedTimetables = async (
+    college: string,
+    major: string,
+    grade: string,
+  ) => {
     if (!session?.user) {
       openAlert(true, '데이터를 불러오는데 실패했습니다.');
       return;
@@ -123,6 +127,7 @@ export default function Add({ semester, timetables }: IAdd) {
     const { ok, message } = await saveTimetables(
       id as string,
       nickname as string,
+      college,
       major,
       grade,
     );
@@ -137,6 +142,7 @@ export default function Add({ semester, timetables }: IAdd) {
   const saveTimetables = async (
     id: string,
     nickname: string,
+    college: string,
     major: string,
     grade: string,
   ) => {
@@ -147,6 +153,7 @@ export default function Add({ semester, timetables }: IAdd) {
       id,
       nickname,
       semester,
+      college,
       major,
       grade,
       totalGrades,

--- a/pages/my/index.tsx
+++ b/pages/my/index.tsx
@@ -21,9 +21,6 @@ interface IMypage {
 
 export default function Mypage({ semesters, user }: IMypage) {
   const [semester, setSemester] = useState(semesters[0]);
-  const handleSemesterChange = (semester: string) => {
-    setSemester(semester);
-  };
 
   const { email: id } = user;
   const { data, isLoading, refetch } = useUserTimetable(id, semester);
@@ -92,11 +89,7 @@ export default function Mypage({ semesters, user }: IMypage) {
     <Wrapper>
       <ContentsWrapper>
         <OperationWrapper>
-          <Select
-            items={semesters}
-            value={semester}
-            onChange={handleSemesterChange}
-          />
+          <Select items={semesters} value={semester} onChange={setSemester} />
           {getOperaionButton()}
         </OperationWrapper>
         <Main>{getViewer()}</Main>

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -1,6 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import type { TypeMajorMap } from '@/types/timetable';
+import type { TypeColleges, TypeMajorMap } from '@/types/timetable';
+import { GRADES } from '@/consts/timetable';
+import ConditionSelector from '@/components/main/ConditionSelector';
+import { useStatisticsTimetables } from '@/queries/timetable/query';
+import CircularProgress from '@mui/material/CircularProgress';
 
 interface IStatistics {
   semesters: string[];
@@ -8,38 +12,110 @@ interface IStatistics {
 }
 
 export default function Statistics({ semesters, majorMap }: IStatistics) {
-  const handleSearch = (
-    semester: string,
-    college: string,
-    major: string,
-    grade: string,
-  ) => {
-    console.log(semester, college, major, grade);
+  const {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  } = useCondition(semesters, majorMap);
+
+  const { isFetching, data, refetch } = useStatisticsTimetables(
+    semester,
+    college,
+    major,
+    grade,
+  );
+
+  const handleSearch = () => {
+    refetch();
   };
+
+  console.log(isFetching, data);
 
   return (
     <Wrapper>
       <ContentsWrapper>
         <ConditionSelector
           semesters={semesters}
-          majorMap={majorMap}
+          semester={semester}
+          setSemester={setSemester}
+          colleges={colleges}
+          college={college}
+          setCollege={setCollege}
+          majors={majors}
+          major={major}
+          setMajor={setMajor}
+          grades={grades}
+          grade={grade}
+          setGrade={setGrade}
           handleSearch={handleSearch}
         />
       </ContentsWrapper>
+      <Main>
+        {isFetching ? (
+          <SpinnerWrapper>
+            <CircularProgress size={60} />
+          </SpinnerWrapper>
+        ) : (
+          <ChartWrapper>Hello</ChartWrapper>
+        )}
+      </Main>
     </Wrapper>
   );
+}
+
+function useCondition(semesters: string[], majorMap: TypeMajorMap) {
+  const [semester, setSemester] = useState(semesters[0]);
+
+  const colleges = ['모든 단과대학', ...Object.keys(majorMap)];
+  const [college, setCollege] = useState(colleges[0]);
+
+  const majors =
+    college === colleges[0]
+      ? ['모든 과']
+      : ['모든 과', ...majorMap[college as TypeColleges]];
+  const [major, setMajor] = useState(majors[0]);
+
+  const grades = ['모든 학년', ...GRADES];
+  const [grade, setGrade] = useState(grades[0]);
+
+  useEffect(() => {
+    setMajor(majors[0]);
+  }, [college]);
+
+  return {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  };
 }
 
 const Wrapper = styled.div`
   width: 100%;
   padding: 10px;
   display: flex;
+  align-items: center;
   justify-content: center;
+  flex-direction: column;
 `;
 
 const ContentsWrapper = styled.div`
   width: 100%;
-  height: 100%;
   @media (min-width: ${({ theme: { size } }) => size.mobile}) {
     width: 950px;
   }
@@ -48,13 +124,29 @@ const ContentsWrapper = styled.div`
   flex-direction: column;
 `;
 
+const Main = styled.main`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SpinnerWrapper = styled.div`
+  height: 50vh;
+  display: flex;
+  align-items: center;
+`;
+
+const ChartWrapper = styled.div`
+  display: flex;
+`;
+
 import Layout from '@/components/Layout';
 Statistics.getLayout = function getLayout(page: JSX.Element) {
   return <Layout>{page}</Layout>;
 };
 
 import { read } from '@/utils/json';
-import ConditionSelector from '@/components/main/ConditionSelector';
 export async function getStaticProps() {
   const semesters = read<string[]>('semesters');
   const majorMap = read<TypeMajorMap>('majorMap');

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -1,18 +1,63 @@
 import React from 'react';
+import styled from 'styled-components';
+import type { TypeMajorMap } from '@/types/timetable';
 
-export default function Statistics() {
-  return <div>statistics</div>;
+interface IStatistics {
+  semesters: string[];
+  majorMap: TypeMajorMap;
 }
+
+export default function Statistics({ semesters, majorMap }: IStatistics) {
+  const handleSearch = (
+    semester: string,
+    college: string,
+    major: string,
+    grade: string,
+  ) => {
+    console.log(semester, college, major, grade);
+  };
+
+  return (
+    <Wrapper>
+      <ContentsWrapper>
+        <ConditionSelector
+          semesters={semesters}
+          majorMap={majorMap}
+          handleSearch={handleSearch}
+        />
+      </ContentsWrapper>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 10px;
+  display: flex;
+  justify-content: center;
+`;
+
+const ContentsWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  @media (min-width: ${({ theme: { size } }) => size.mobile}) {
+    width: 950px;
+  }
+
+  display: flex;
+  flex-direction: column;
+`;
 
 import Layout from '@/components/Layout';
 Statistics.getLayout = function getLayout(page: JSX.Element) {
   return <Layout>{page}</Layout>;
 };
 
-// import { redirectNotAuthUser } from '@/utils/auth';
-// import { NextPageContext } from 'next';
+import { read } from '@/utils/json';
+import ConditionSelector from '@/components/main/ConditionSelector';
+export async function getStaticProps() {
+  const semesters = read<string[]>('semesters');
+  const majorMap = read<TypeMajorMap>('majorMap');
 
-// export async function getServerSideProps(context: NextPageContext) {
-//   const returnObject = await redirectNotAuthUser(context.req);
-//   return returnObject;
-// }
+  return { props: { semesters, majorMap } };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model Timetables {
   id          String
   nickname    String
   semester    String
+  college     String
   major       String
   grade       String
   totalGrades Int

--- a/queries/timetable/query.ts
+++ b/queries/timetable/query.ts
@@ -7,6 +7,7 @@ import {
 import { get, post, _delete } from '../httpMethods';
 import {
   majorMapService,
+  statisticsGetService,
   userDeleteService,
   userGetService,
   userPostService,
@@ -76,6 +77,23 @@ export function useUserTimetable(id: string, semester: string) {
     ['userTimetable', id, semester],
     () => get(userGetService, queryString),
     { staleTime: 60 * 1000 * 60 },
+  );
+
+  return queryResult;
+}
+
+export function useStatisticsTimetables(
+  semester: string,
+  college: string,
+  major: string,
+  grade: string,
+) {
+  const queryString = `?semester=${semester}&college=${college}&major=${major}&grade=${grade}`;
+
+  const queryResult = useQuery<IUserTimetableResponse>(
+    ['statistics', semester, college, major, grade],
+    () => get(statisticsGetService, queryString),
+    { staleTime: 60 * 1000 * 60, enabled: false },
   );
 
   return queryResult;

--- a/queries/timetable/services.ts
+++ b/queries/timetable/services.ts
@@ -5,6 +5,7 @@ const MAJOR_MAP_URL = 'majorMap';
 const USER_POST_URL = 'user/post';
 const USER_GET_URL = 'user/get';
 const USER_DELETE_URL = 'user/delete';
+const STATISTICS_GET_URL = 'statistics/get';
 
 export const majorMapService = axios.create({
   baseURL: `${BASE_URL}/${MAJOR_MAP_URL}/`,
@@ -20,4 +21,8 @@ export const userGetService = axios.create({
 
 export const userDeleteService = axios.create({
   baseURL: `${BASE_URL}/${USER_DELETE_URL}/`,
+});
+
+export const statisticsGetService = axios.create({
+  baseURL: `${BASE_URL}/${STATISTICS_GET_URL}/`,
 });

--- a/types/apiResponse.ts
+++ b/types/apiResponse.ts
@@ -18,3 +18,7 @@ export interface IDefaultDeleteResponse {
 export interface IUserTimetableResponse extends IDefaultResponse {
   userTimetable?: IUserTimetable;
 }
+
+export interface IUserTimetablesResponse extends IDefaultResponse {
+  userTimetables?: IUserTimetable[];
+}

--- a/types/timetable.ts
+++ b/types/timetable.ts
@@ -39,6 +39,7 @@ export interface IUserTimetable {
   id: string;
   nickname: string;
   semester: string;
+  college: string;
   major: string;
   grade: string;
   totalGrades: number;


### PR DESCRIPTION
## 개요

통계를 위한 조건에 맞는 user timetables 불러오기 구현

## 작업내용

1. 학기, 단과대, 과, 학년을 선택하는 컴포넌트 구현
2. user timetable model에 단과대(college) 추가
3. 조건에 맞는 user timetables 불러오는 api 구현
4. 조건에 맞는 user timetables 불러오는 react query 구현
5. statistics page가 마운트 됐을 때 바로 fetch 하는 것이 아니라 검색 버튼을 눌렀을 때 데이터 fetch
   1. react query의 초기 enabled는 false임