### PR TITLE
등록된 시간표 목록을 확인할 수 있는 페이지 구현

### DIFF
--- a/components/home/ContentsManager.tsx
+++ b/components/home/ContentsManager.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import type { IUserTimetable } from '@/types/timetable';
+import styled from 'styled-components';
+import Feed from './Feed';
+
+interface IContentsManager {
+  userTimetables: IUserTimetable[];
+}
+
+export default function ContentsManager({ userTimetables }: IContentsManager) {
+  const length = userTimetables.length;
+  return (
+    <Wrapper>
+      {0 < length ? (
+        userTimetables.map(
+          ({ id, semester, timetables, major, nickname, totalGrades }) => (
+            <Feed
+              key={`${id}${semester}`}
+              timetables={timetables}
+              major={major}
+              nickname={nickname}
+              totalGrades={totalGrades}
+            />
+          ),
+        )
+      ) : (
+        <>저장된 데이터가 없습니다.</>
+      )}
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+`;

--- a/components/home/Feed.tsx
+++ b/components/home/Feed.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import type { ITimetable } from '@/types/timetable';
+import styled from 'styled-components';
+import Viewer from '@/components/timetable/viewer';
+
+interface IFeed {
+  timetables: ITimetable[];
+  major: string;
+  nickname: string;
+  totalGrades: number;
+}
+
+export default function Feed({
+  timetables,
+  major,
+  nickname,
+  totalGrades,
+}: IFeed) {
+  return (
+    <Wrapper>
+      <InfoWrapper>
+        <p>{major}</p>
+        <p>{nickname}</p>
+        <p>{`총 ${totalGrades}학점`}</p>
+      </InfoWrapper>
+      <Viewer fullMode={false} timetables={timetables} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+`;
+
+const InfoWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 5px;
+`;

--- a/components/main/ConditionSelector.tsx
+++ b/components/main/ConditionSelector.tsx
@@ -16,7 +16,8 @@ interface IConditionSelector {
   grades: string[];
   grade: string;
   setGrade: React.Dispatch<React.SetStateAction<string>>;
-  handleSearch: () => void;
+  needSearchButton: boolean;
+  handleSearch?: () => void;
 }
 
 export default function ConditionSelector({
@@ -32,6 +33,7 @@ export default function ConditionSelector({
   grades,
   grade,
   setGrade,
+  needSearchButton,
   handleSearch,
 }: IConditionSelector) {
   return (
@@ -62,11 +64,22 @@ export default function ConditionSelector({
           width={'100%'}
         />
       </SelectWrapper>
-      <ButtonWrapper>
-        <StyledButton variant='contained' onClick={handleSearch}>
-          검색
-        </StyledButton>
-      </ButtonWrapper>
+      {needSearchButton ? (
+        <ButtonWrapper>
+          <StyledButton
+            variant='contained'
+            onClick={() => {
+              if (handleSearch) {
+                handleSearch();
+              }
+            }}
+          >
+            검색
+          </StyledButton>
+        </ButtonWrapper>
+      ) : (
+        <></>
+      )}
     </Wrapper>
   );
 }

--- a/pages/api/timetable/statistics/get.ts
+++ b/pages/api/timetable/statistics/get.ts
@@ -49,7 +49,9 @@ export default async function handler(
         .status(200)
         .json({ ok: true, message: '불러오기 완료', userTimetables });
     } else if (!result) {
-      res.status(200).json({ ok: true, message: '저장된 시간표가 없음' });
+      res
+        .status(200)
+        .json({ ok: false, message: '불러오기 실패 - 데이터베이스 오류' });
     }
   } catch {
     res

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,18 +1,141 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import type { TypeColleges, TypeMajorMap } from '@/types/timetable';
+import { GRADES } from '@/consts/timetable';
+import ConditionSelector from '@/components/main/ConditionSelector';
+import { useFeedTimetables } from '@/queries/timetable/query';
+import CircularProgress from '@mui/material/CircularProgress';
+import ContentsManager from '@/components/home/ContentsManager';
 
-export default function Home() {
-  return <div>index</div>;
+interface IStatistics {
+  semesters: string[];
+  majorMap: TypeMajorMap;
 }
+
+export default function Home({ semesters, majorMap }: IStatistics) {
+  const {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  } = useCondition(semesters, majorMap);
+
+  const { isFetching, data } = useFeedTimetables(
+    semester,
+    college,
+    major,
+    grade,
+  );
+
+  const renderMainContents = () => {
+    if (isFetching) {
+      return (
+        <SpinnerWrapper>
+          <CircularProgress size={60} />
+        </SpinnerWrapper>
+      );
+    } else if (data && data.userTimetables) {
+      return <ContentsManager userTimetables={data.userTimetables} />;
+    } else {
+      return <></>;
+    }
+  };
+
+  return (
+    <Wrapper>
+      <ConditionSelector
+        semesters={semesters}
+        semester={semester}
+        setSemester={setSemester}
+        colleges={colleges}
+        college={college}
+        setCollege={setCollege}
+        majors={majors}
+        major={major}
+        setMajor={setMajor}
+        grades={grades}
+        grade={grade}
+        setGrade={setGrade}
+        needSearchButton={false}
+      />
+      <Main>{renderMainContents()}</Main>
+    </Wrapper>
+  );
+}
+
+function useCondition(semesters: string[], majorMap: TypeMajorMap) {
+  const [semester, setSemester] = useState(semesters[0]);
+
+  const colleges = ['모든 단과대학', ...Object.keys(majorMap)];
+  const [college, setCollege] = useState(colleges[0]);
+
+  const majors =
+    college === colleges[0]
+      ? ['모든 과']
+      : ['모든 과', ...majorMap[college as TypeColleges]];
+  const [major, setMajor] = useState(majors[0]);
+
+  const grades = ['모든 학년', ...GRADES];
+  const [grade, setGrade] = useState(grades[0]);
+
+  useEffect(() => {
+    setMajor(majors[0]);
+  }, [college]);
+
+  return {
+    semester,
+    setSemester,
+    colleges,
+    college,
+    setCollege,
+    majors,
+    major,
+    setMajor,
+    grades,
+    grade,
+    setGrade,
+  };
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  @media (min-width: ${({ theme: { size } }) => size.mobile}) {
+    width: 950px;
+  }
+  margin: 0 auto;
+  padding: 10px;
+`;
+
+const Main = styled.main`
+  width: 100%;
+  margin-top: 30px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const SpinnerWrapper = styled.div`
+  height: 40vh;
+  display: flex;
+  align-items: center;
+`;
 
 import Layout from '@/components/Layout';
 Home.getLayout = function getLayout(page: JSX.Element) {
   return <Layout>{page}</Layout>;
 };
 
-// import { redirectNotAuthUser } from '@/utils/auth';
-// import { NextPageContext } from 'next';
+import { read } from '@/utils/json';
+export async function getStaticProps() {
+  const semesters = read<string[]>('semesters');
+  const majorMap = read<TypeMajorMap>('majorMap');
 
-// export async function getServerSideProps(context: NextPageContext) {
-//   const returnObject = await redirectNotAuthUser(context.req);
-//   return returnObject;
-// }
+  return { props: { semesters, majorMap } };
+}

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -5,6 +5,8 @@ import { GRADES } from '@/consts/timetable';
 import ConditionSelector from '@/components/main/ConditionSelector';
 import { useStatisticsTimetables } from '@/queries/timetable/query';
 import CircularProgress from '@mui/material/CircularProgress';
+import ContentsManager from '@/components/statistics/ContentsManager';
+import { useQueryClient } from '@tanstack/react-query';
 
 interface IStatistics {
   semesters: string[];
@@ -51,6 +53,13 @@ export default function Statistics({ semesters, majorMap }: IStatistics) {
   const handleSearch = () => {
     refetch();
   };
+
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    const queryKey = ['statistics', semester, college, major, grade];
+    const data = queryClient.getQueryData(queryKey);
+    if (!data) refetch();
+  }, []);
 
   const renderMainContents = () => {
     if (isFetching) {
@@ -151,7 +160,7 @@ Statistics.getLayout = function getLayout(page: JSX.Element) {
 };
 
 import { read } from '@/utils/json';
-import ContentsManager from '@/components/statistics/ContentsManager';
+import { IUserTimetablesResponse } from '@/types/apiResponse';
 export async function getStaticProps() {
   const semesters = read<string[]>('semesters');
   const majorMap = read<TypeMajorMap>('majorMap');

--- a/pages/statistics.tsx
+++ b/pages/statistics.tsx
@@ -12,21 +12,6 @@ interface IStatistics {
   semesters: string[];
   majorMap: TypeMajorMap;
 }
-function useStatistics(
-  semester: string,
-  college: string,
-  major: string,
-  grade: string,
-) {
-  const { isFetching, data, refetch } = useStatisticsTimetables(
-    semester,
-    college,
-    major,
-    grade,
-  );
-
-  return { isFetching, data, refetch };
-}
 
 export default function Statistics({ semesters, majorMap }: IStatistics) {
   const {
@@ -43,7 +28,7 @@ export default function Statistics({ semesters, majorMap }: IStatistics) {
     setGrade,
   } = useCondition(semesters, majorMap);
 
-  const { isFetching, data, refetch } = useStatistics(
+  const { isFetching, data, refetch } = useStatisticsTimetables(
     semester,
     college,
     major,
@@ -90,6 +75,7 @@ export default function Statistics({ semesters, majorMap }: IStatistics) {
         grades={grades}
         grade={grade}
         setGrade={setGrade}
+        needSearchButton={true}
         handleSearch={handleSearch}
       />
       <Main>{renderMainContents()}</Main>
@@ -160,7 +146,6 @@ Statistics.getLayout = function getLayout(page: JSX.Element) {
 };
 
 import { read } from '@/utils/json';
-import { IUserTimetablesResponse } from '@/types/apiResponse';
 export async function getStaticProps() {
   const semesters = read<string[]>('semesters');
   const majorMap = read<TypeMajorMap>('majorMap');

--- a/queries/timetable/query.ts
+++ b/queries/timetable/query.ts
@@ -39,6 +39,7 @@ export function useUserPostTimetable() {
   return async (userTimetable: IUserTimetable) => {
     const { id, semester } = userTimetable;
     await invalidateUserTimetable(queryClient, id, semester);
+    removeStatisticsQueries(queryClient, semester);
 
     return await mutateAsync(userTimetable);
   };
@@ -56,6 +57,7 @@ export function useUserDeleteTimetable() {
   const queryClient = useQueryClient();
   return async (id: string, semester: string) => {
     await invalidateUserTimetable(queryClient, id, semester);
+    removeStatisticsQueries(queryClient, semester);
 
     return await mutateAsync({ id, semester });
   };
@@ -68,6 +70,12 @@ async function invalidateUserTimetable(
 ) {
   await queryClient.invalidateQueries({
     queryKey: ['userTimetable', id, semester],
+  });
+}
+
+function removeStatisticsQueries(queryClient: QueryClient, semester: string) {
+  queryClient.removeQueries({
+    queryKey: ['statistics', semester],
   });
 }
 

--- a/queries/timetable/query.ts
+++ b/queries/timetable/query.ts
@@ -107,3 +107,20 @@ export function useStatisticsTimetables(
 
   return queryResult;
 }
+
+export function useFeedTimetables(
+  semester: string,
+  college: string,
+  major: string,
+  grade: string,
+) {
+  const queryString = `?semester=${semester}&college=${college}&major=${major}&grade=${grade}`;
+
+  const queryResult = useQuery<IUserTimetablesResponse>(
+    ['statistics', semester, college, major, grade],
+    () => get(statisticsGetService, queryString),
+    { staleTime: 60 * 1000 * 60 },
+  );
+
+  return queryResult;
+}


### PR DESCRIPTION
## 개요

등록된 시간표 목록을 확인할 수 있는 페이지 구현

## 작업내용

1. userTimetable이 변경될 때 statistics cache를 remove
2. statistics page가 마운트 될 때 cache data가 없으면 refetch
3. timetable viewer 컴포넌트 시간표에 최적화된 높이를 계산하는 fullMode(false일 때) 기능 추가
4. main, statistics 두 페이지에서 사용하는 조건 검색 컴포넌트에 검색버튼 사용 유무를 정할 수 있게 수정
5. feed 컴포넌트 구현 및 main 페이지에 적용