### PR TITLE
timetables 테이블에 좋아요 누른 유저목록 추가

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL='mysql://aur8zkqt84199zjwui8f:pscale_pw_ktwwuVsdE7WEzpBVlHlfD7Oq1sBOF62dQDzgvkjcemy@ap-northeast.connect.psdb.cloud/inu-timetable-dev?sslaccept=strict'
+DATABASE_URL='mysql://hgatsmwniwrscdnzy6iu:pscale_pw_MP8PHhUL4lKJGnTljxW1ednGNb6CUHNiB9tO8eGxFbQ@ap-northeast.connect.psdb.cloud/inu-timetable?sslaccept=strict'

--- a/components/home/ContentsManager.tsx
+++ b/components/home/ContentsManager.tsx
@@ -9,6 +9,7 @@ interface IContentsManager {
 
 export default function ContentsManager({ userTimetables }: IContentsManager) {
   const length = userTimetables.length;
+
   return (
     <Wrapper>
       {0 < length ? (
@@ -21,6 +22,7 @@ export default function ContentsManager({ userTimetables }: IContentsManager) {
             grade,
             nickname,
             totalGrades,
+            likeUsers,
           }) => (
             <Feed
               key={`${id}${semester}`}
@@ -29,6 +31,7 @@ export default function ContentsManager({ userTimetables }: IContentsManager) {
               grade={grade}
               nickname={nickname}
               totalGrades={totalGrades}
+              likeUsers={likeUsers}
             />
           ),
         )

--- a/components/home/Feed.tsx
+++ b/components/home/Feed.tsx
@@ -10,6 +10,7 @@ interface IFeed {
   grade: string;
   nickname: string;
   totalGrades: number;
+  likeUsers: string[];
 }
 
 export default function Feed({
@@ -18,8 +19,8 @@ export default function Feed({
   grade,
   nickname,
   totalGrades,
+  likeUsers,
 }: IFeed) {
-  const like = 30;
   const isLiked = false;
 
   return (
@@ -37,7 +38,7 @@ export default function Feed({
         >
           {isLiked ? <FcLike size='40' /> : <FcLikePlaceholder size='40' />}
         </IconWrapper>
-        {`좋아요 ${like}개`}
+        {`좋아요 ${likeUsers.length}개`}
       </LikeWrapper>
     </Wrapper>
   );

--- a/pages/api/timetable/feed/get.ts
+++ b/pages/api/timetable/feed/get.ts
@@ -90,6 +90,7 @@ function parseUserTimetablesObject(result: Timetables[]) {
       grade,
       totalGrades,
       timetables,
+      likeUsers,
     }) => {
       return {
         index,
@@ -101,6 +102,7 @@ function parseUserTimetablesObject(result: Timetables[]) {
         grade,
         totalGrades,
         timetables: JSON.parse(timetables as string) as ITimetable[],
+        likeUsers: JSON.parse(likeUsers as string) as string[],
       };
     },
   );

--- a/pages/api/timetable/user/get.ts
+++ b/pages/api/timetable/user/get.ts
@@ -40,6 +40,7 @@ export default async function handler(
         grade,
         totalGrades,
         timetables,
+        likeUsers,
       } = result;
 
       const userTimetable = {
@@ -52,6 +53,7 @@ export default async function handler(
         grade,
         totalGrades,
         timetables: JSON.parse(timetables as string) as ITimetable[],
+        likeUsers: JSON.parse(likeUsers as string) as string[],
       };
 
       res

--- a/pages/api/timetable/user/post.ts
+++ b/pages/api/timetable/user/post.ts
@@ -25,6 +25,7 @@ export default async function handler(
     grade,
     totalGrades,
     timetables,
+    likeUsers,
   } = req.body;
 
   try {
@@ -38,6 +39,7 @@ export default async function handler(
         grade,
         totalGrades,
         timetables: JSON.stringify(timetables),
+        likeUsers: JSON.stringify(likeUsers),
       },
     });
     res.status(200).json({ ok: true, message: '저장 완료' });

--- a/pages/my/add/[semester].tsx
+++ b/pages/my/add/[semester].tsx
@@ -159,6 +159,7 @@ export default function Add({ semester, timetables }: IAdd) {
       grade,
       totalGrades,
       timetables: addedTimetables,
+      likeUsers: [],
     });
 
     setSaveLoading(false);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,4 +25,5 @@ model Timetables {
   grade       String
   totalGrades Int
   timetables  Json
+  likeUsers Json
 }

--- a/types/timetable.ts
+++ b/types/timetable.ts
@@ -45,4 +45,5 @@ export interface IUserTimetable {
   grade: string;
   totalGrades: number;
   timetables: ITimetable[];
+  likeUsers: string[];
 }


### PR DESCRIPTION
# 개요

timetables 테이블에 좋아요 누른 유저목록 추가

## 작업내용

1. prisma model에 likeUsers 추가
2. likeUsers type 추가
3. 유저 시간표 get, post 할 때 likeUsers 추가
4. 피드의 좋아요 개수 표시